### PR TITLE
refactor ref_data to use RefCounted

### DIFF
--- a/scenes/entities/commander/commander.gd
+++ b/scenes/entities/commander/commander.gd
@@ -2,6 +2,7 @@ extends Unit
 
 
 func spawn_actors():
+	var unit_data := RefData.get_unit_data(unit_name)
 	var actor: Actor = null
 	if team == Constants.TEAM_ALLY:
 		actor = Factory.create_player_actor(self, unit_name, team)

--- a/scenes/entities/unit/unit.gd
+++ b/scenes/entities/unit/unit.gd
@@ -13,6 +13,6 @@ var _actors : Array[Actor] = []
 
 ## spawn actors onto the combat map
 func spawn_actors():
-	var unit_data = RefData.unit_data[unit_name]
-	for i in unit_data["num_units"]:
+	var unit_data := RefData.get_unit_data(unit_name) as UnitData
+	for i in unit_data.num_units:
 		_actors.append(Factory.create_actor(self, unit_name, team))

--- a/scripts/data classes/unit_data.gd
+++ b/scripts/data classes/unit_data.gd
@@ -1,0 +1,26 @@
+class_name UnitData 
+extends RefCounted
+
+var max_health := 100
+var max_stamina := 100
+var regen := 100
+var dodge := 100
+var magic_defence := 10
+var mundane_defence := 10
+var attack := 50
+var attack_speed := 100
+var penetration := 100
+var crit_chance := 100
+var move_speed := 150
+var stamina := 10
+var num_units := 5
+var faction := "faction1"
+var gold_cost := 100
+var tier := 1
+var path_base_sprites := Constants.PATH_SPRITES_ACTORS
+var actions := {}
+
+func _init(overrides := {}):
+	for key in overrides:
+		if key in self:
+			set(key, overrides[key])

--- a/scripts/globals/factory.gd
+++ b/scripts/globals/factory.gd
@@ -120,13 +120,25 @@ func _get_base_actor_instance(
 func _create_actor_stats(unit_data: UnitData) -> ActorStats:
 	var stats = ActorStats.new()
 	
-	for property_dict in stats.get_property_list():
-		if property_dict.name == "script":
-			continue
-		elif property_dict.name in unit_data:
-			# Left this here as it helps debugging, just remove the comment when needed.
-#			print("name: %s"%[property_dict.name])
-			stats.set(property_dict.name, unit_data.get(property_dict.name))
+	stats.max_health = unit_data.max_health
+	stats.health = unit_data.max_health
+	stats.max_stamina = unit_data.max_stamina
+	stats.stamina = unit_data.max_stamina
+	
+	stats.base_regen = unit_data.regen
+	stats.base_dodge = unit_data.dodge
+	stats.base_magic_defence = unit_data.magic_defence
+	stats.base_mundane_defence = unit_data.mundane_defence
+	stats.base_attack = unit_data.attack
+	stats.base_attack_speed = unit_data.attack_speed
+	stats.base_crit_chance = unit_data.crit_chance
+	stats.base_penetration = unit_data.penetration
+	stats.base_move_speed = unit_data.move_speed
+	
+	stats.num_units = unit_data.num_units
+	stats.faction = unit_data.faction
+	stats.gold_cost = unit_data.gold_cost
+	stats.tier = unit_data.tier
 	
 	return stats
 

--- a/scripts/globals/ref_data.gd
+++ b/scripts/globals/ref_data.gd
@@ -3,138 +3,82 @@ extends Node
 ##
 ## Read Only.
 
-const unit_data: Dictionary = {
-	"copper_golem": {
-		"max_health": 100,
-		"max_stamina": 100,
-		"regen": 100,
-		"dodge": 100,
-		"magic_defence": 10,
-		"mundane_defence": 10,
-		"attack": 50,
-		"attack_speed": 100,
-		"penetration": 100,
-		"crit_chance": 100,
-		"move_speed": 150,
-		"stamina": 10,
-		"num_units": 5,
-		"faction": "faction1",
-		"gold_cost": 100,
-		"tier": 1,
-		"actions": {  ## must use {Action Type, script name} (NOT class name)
-			Constants.ActionType.ATTACK : [
-				"smash",
-			],
-			Constants.ActionType.REACTION : {
-				Constants.ActionTrigger.ON_DEAL_DAMAGE : [
-					"spiky_shell",
-				]
-			},
-		},
-		"path_base_sprites": Constants.PATH_SPRITES_ACTORS,
-	},
-	"conjurer": {
-		"max_health": 70,
-		"max_stamina": 100,
-		"regen": 100,
-		"dodge": 100,
-		"magic_defence": 2,
-		"mundane_defence": 3,
-		"attack": 33,
-		"attack_speed": 100,
-		"penetration": 100,
-		"crit_chance": 100,
-		"move_speed": 200,
-		"stamina": 10,
-		"num_units": 3,
-		"faction": "faction1",
-		"gold_cost": 100,
-		"tier": 1,
-		"actions": {  ## must use Action Type, script name (NOT class name)
-			Constants.ActionType.ATTACK : [
-				"wand_blast",
-				"heal",
-			],
-			Constants.ActionType.REACTION : { }
-		},
-		"path_base_sprites": Constants.PATH_SPRITES_ACTORS,
-	},
-	"poet": {
-		"max_health": 70,
-		"max_stamina": 100,
-		"regen": 100,
-		"dodge": 100,
-		"magic_defence": 2,
-		"mundane_defence": 3,
-		"attack": 33,
-		"attack_speed": 100,
-		"penetration": 100,
-		"crit_chance": 100,
-		"move_speed": 200,
-		"stamina": 10,
-		"num_units": 2,
-		"faction": "faction1",
-		"gold_cost": 100,
-		"tier": 1,
-		"actions": {  ## must use Action Type, script name (NOT class name)
-			Constants.ActionType.ATTACK : [
-				"stanza",
-			],
-			Constants.ActionType.REACTION : { }
-		},
-		"path_base_sprites": Constants.PATH_SPRITES_ACTORS,
-	},
-	"cavalier": {
-		"max_health": 100,
-		"max_stamina": 100,
-		"regen": 100,
-		"dodge": 100,
-		"magic_defence": 10,
-		"mundane_defence": 10,
-		"attack": 50,
-		"attack_speed": 100,
-		"penetration": 100,
-		"crit_chance": 100,
-		"move_speed": 150,
-		"stamina": 10,
-		"num_units": 1,
-		"faction": "faction1",
-		"gold_cost": 100,
-		"tier": 1,
-		"actions": {  ## must use {Action Type, script name} (NOT class name)
-			Constants.ActionType.ATTACK : [
-				"smash",
-				"wand_blast",
-			],
-			Constants.ActionType.REACTION : { },
-		},
-		"path_base_sprites": Constants.PATH_SPRITES_COMMANDERS,
-	},
-	"knight": {
-		"max_health": 100,
-		"max_stamina": 100,
-		"regen": 100,
-		"dodge": 100,
-		"magic_defence": 10,
-		"mundane_defence": 10,
-		"attack": 50,
-		"attack_speed": 100,
-		"penetration": 100,
-		"crit_chance": 100,
-		"move_speed": 150,
-		"stamina": 10,
-		"num_units": 1,
-		"faction": "faction1",
-		"gold_cost": 100,
-		"tier": 1,
-		"actions": {  ## must use {Action Type, script name} (NOT class name)
-			Constants.ActionType.ATTACK : [
-				"smash",
-				"wand_blast",
-			],
-			Constants.ActionType.REACTION : { },
-		},
-		"path_base_sprites": Constants.PATH_SPRITES_COMMANDERS,
-	},
-
-}
+func get_unit_data(unit_name: String) -> UnitData:
+	var value: UnitData = null
+	
+	match unit_name:
+		"copper_golem":
+			var actions = {  ## must use {Action Type, script name} (NOT class name)
+				Constants.ActionType.ATTACK : [
+					"smash",
+				],
+				Constants.ActionType.REACTION : {
+					Constants.ActionTrigger.ON_DEAL_DAMAGE : [
+						"spiky_shell",
+					]
+				}
+			}
+			value = UnitData.new({
+				"actions": actions,
+			})
+		"conjurer":
+			var actions := {  ## must use Action Type, script name (NOT class name)
+				Constants.ActionType.ATTACK : [
+					"wand_blast",
+					"heal",
+				],
+				Constants.ActionType.REACTION : { }
+			}
+			value = UnitData.new({
+				"max_health": 70,
+				"magic_defence": 2,
+				"mundane_defence": 3,
+				"attack": 33,
+				"move_speed": 200,
+				"num_units": 3,
+				"actions": actions,
+			})
+		"poet":
+			var actions := {  ## must use Action Type, script name (NOT class name)
+				Constants.ActionType.ATTACK : [
+					"stanza",
+				],
+				Constants.ActionType.REACTION : { }
+			}
+			value = UnitData.new({
+				"max_health": 70,
+				"magic_defence": 2,
+				"mundane_defence": 3,
+				"attack": 33,
+				"move_speed": 200,
+				"num_units": 2,
+				"actions": actions,
+			})
+		"cavalier":
+			var actions := {  ## must use {Action Type, script name} (NOT class name)
+				Constants.ActionType.ATTACK : [
+					"smash",
+					"wand_blast",
+				],
+				Constants.ActionType.REACTION : { },
+			}
+			value = UnitData.new({
+				"num_units": 1,
+				"actions": actions,
+				"path_base_sprites": Constants.PATH_SPRITES_COMMANDERS
+			})
+		"knight":
+			var actions := {  ## must use {Action Type, script name} (NOT class name)
+				Constants.ActionType.ATTACK : [
+					"smash",
+					"wand_blast",
+				],
+				Constants.ActionType.REACTION : { },
+			}
+			value = UnitData.new({
+				"num_units": 1,
+				"actions": actions,
+				"path_base_sprites": Constants.PATH_SPRITES_COMMANDERS
+			})
+	
+	return value


### PR DESCRIPTION
This is a "proposal" for a way to use ref_data with RefCounted objects instead of Dictionaries. 

I think it will be a little bit easier to create new ones when you don't want to override a lot of stats, adds type completion when using it in code, and automates passing the data from UnitData to ActorStats, so we don't have to give it maintenance, just add the same property on both and it works.