### PR TITLE
Introduce Fleeing behavior on AI Commander

### DIFF
--- a/scenes/entities/actor/actor.gd
+++ b/scenes/entities/actor/actor.gd
@@ -258,9 +258,6 @@ func refresh_target(
 		# relisten to target changes
 		if not _target.is_connected("no_longer_targetable", refresh_target):
 			_target.no_longer_targetable.connect(refresh_target)
-		
-		# update nav agent's target
-		_navigation_agent.set_target_position(_target.global_position)
 
 
 func _refresh_facing() -> void:

--- a/scenes/entities/actor/actor.gd
+++ b/scenes/entities/actor/actor.gd
@@ -150,8 +150,7 @@ func _connect_signals() -> void:
 ########## MAIN LOOP ##########
 
 func _physics_process(_delta) -> void:
-	if is_in_group("alive"):
-		state_machine.update_state()
+	pass
 
 ######### ACTIONS ############
 

--- a/scenes/entities/actor/actor.gd
+++ b/scenes/entities/actor/actor.gd
@@ -262,10 +262,10 @@ func refresh_target(
 
 func _refresh_facing() -> void:
 	if velocity.x < 0:
-		self._facing = Constants.Direction.LEFT
+		_facing = Constants.Direction.LEFT
 		animated_sprite.flip_h = true
 	elif velocity.x > 0:
-		self._facing = Constants.Direction.RIGHT
+		_facing = Constants.Direction.RIGHT
 		animated_sprite.flip_h = false
 
 ## update the size of the target finder

--- a/scenes/entities/actor/actor.gd
+++ b/scenes/entities/actor/actor.gd
@@ -90,7 +90,7 @@ var attack_to_cast : BaseAction = null:
 		if attack_to_cast != null:
 			_update_target_finder_range(int(attack_to_cast.range))
 			print(debug_name + " chose to use " + attack_to_cast.friendly_name + ".")
-var neighbours : Array
+var neighbours : Array[Actor]
 
 ######### UI ATTRIBUTES ###############
 
@@ -159,36 +159,9 @@ func _physics_process(_delta) -> void:
 func move_towards_target() -> void:
 	# get next destination
 	var target_pos : Vector2 = _navigation_agent.get_next_path_position()
-
-	var social_distancing_force : Vector2
-
-	var social_loop_limit : int = 7
-	var distance_to_target : float = _target.global_position.distance_to(self.global_position)
-
-	for i in mini(neighbours.size(), social_loop_limit):
-		var neighbour = neighbours[i]
-		var p1 : Vector2 = self.global_position
-		var p2 : Vector2 = neighbour.global_position
-		var distance : float = p1.distance_to(p2)
-		if distance < distance_to_target and ai.is_enemy(neighbour):
-			_target = neighbour
-			distance_to_target = distance
-		var p3 : Vector2 = p1.direction_to(p2) * maxf((100 - distance * 2), 0)
-		social_distancing_force -= p3
-
-	if neighbours.size() > social_loop_limit:
-		# Approximate the remaining social distancing force that we didn't
-		# bother calculating
-		social_distancing_force *= neighbours.size() / float(social_loop_limit)
-
-	# determine route
-	var direction : Vector2 = global_position.direction_to(target_pos)
-	var desired_velocity : Vector2 = direction * stats.move_speed
-	var steering : Vector2 = (desired_velocity - velocity)
-
-	# update velocity
-	velocity += steering + social_distancing_force
-
+	var social_distancing_force := ai.get_social_distancing_force(_target, neighbours)
+	
+	velocity = ai.get_steered_velocity(velocity, target_pos, social_distancing_force)
 	move_and_slide()
 
 

--- a/scenes/entities/actor/player_actor.gd
+++ b/scenes/entities/actor/player_actor.gd
@@ -55,18 +55,15 @@ func get_target(
 ) -> Actor:
 	# disconnect from current signals on target
 	if current_target:
-		if current_target.no_longer_targetable.is_connected(refresh_target):
-			current_target.no_longer_targetable.disconnect(refresh_target)
+		if current_target.no_longer_targetable.is_connected(_attempt_all_target_refresh):
+			current_target.no_longer_targetable.disconnect(_attempt_all_target_refresh)
 	
 	# get new target
 	var new_target := ai.get_target(target_type, preferences)
 	
 	if new_target != null:
 		# relisten to target changes
-		if not new_target.is_connected("no_longer_targetable", refresh_target):
-			new_target.no_longer_targetable.connect(refresh_target)
-		
-		# update nav agent's target
-		_navigation_agent.set_target_position(new_target.global_position)
+		if not new_target.is_connected("no_longer_targetable", _attempt_all_target_refresh):
+			new_target.no_longer_targetable.connect(_attempt_all_target_refresh)
 	
 	return new_target

--- a/scenes/entities/commander/commander.gd
+++ b/scenes/entities/commander/commander.gd
@@ -7,7 +7,7 @@ func spawn_actors():
 	if team == Constants.TEAM_ALLY:
 		actor = Factory.create_player_actor(self, unit_name, team)
 	else:
-		actor = Factory.create_actor(self, unit_name, team)
+		actor = Factory.create_ai_commander(self, unit_name, team)
 	
 	_actors.append(actor)
 	actor.died.connect(_on_actor_died)

--- a/scenes/entities/commander/commander.gd
+++ b/scenes/entities/commander/commander.gd
@@ -2,12 +2,10 @@ extends Unit
 
 
 func spawn_actors():
-	var unit_data := RefData.get_unit_data(unit_name)
-	var actor: Actor = null
+	var unit_type := Constants.UnitType.AI_COMMANDER
 	if team == Constants.TEAM_ALLY:
-		actor = Factory.create_player_actor(self, unit_name, team)
-	else:
-		actor = Factory.create_ai_commander(self, unit_name, team)
+		unit_type = Constants.UnitType.PLAYER_ACTOR
+	var actor: Actor = Factory.create_actor(self, unit_name, team, unit_type)
 	
 	_actors.append(actor)
 	actor.died.connect(_on_actor_died)

--- a/scenes/entities/unit/unit.gd
+++ b/scenes/entities/unit/unit.gd
@@ -6,6 +6,7 @@ class_name Unit extends Node2D
 # defintions
 @export var team: String
 @export var unit_name: String
+@export var unit_type := Constants.UnitType.AI_NORMAL
 
 # functional
 
@@ -13,6 +14,6 @@ var _actors : Array[Actor] = []
 
 ## spawn actors onto the combat map
 func spawn_actors():
-	var unit_data := RefData.get_unit_data(unit_name) as UnitData
+	var unit_data := RefData.get_unit_data(unit_name, unit_type) as UnitData
 	for i in unit_data.num_units:
 		_actors.append(Factory.create_actor(self, unit_name, team))

--- a/scenes/stages/commander_test/comander_test.gd
+++ b/scenes/stages/commander_test/comander_test.gd
@@ -18,7 +18,10 @@ func _get_units_from_troupe() -> void:
 	for key in _units.keys():
 		for i in range(num_unit_per_team):
 			unit_name = unit_choices[key][0]
-			var unit = Factory.create_unit(self, unit_name, key)
+			var unit_type := Constants.UnitType.AI_COMMANDER
+			if key == Constants.TEAM_ALLY:
+				unit_type = Constants.UnitType.PLAYER_ACTOR
+			var unit = Factory.create_unit(self, unit_name, key, unit_type)
 			unit.set_name(unit_name.to_pascal_case() + "_Unit")
 			_units[key].append(unit)
 

--- a/scripts/components/actor_ai.gd
+++ b/scripts/components/actor_ai.gd
@@ -1,7 +1,6 @@
 class_name ActorAI extends Node
 
 var _creator : Actor
-var target : Actor
 
 func _init(creator: Actor) -> void:
 	_creator = creator
@@ -80,6 +79,45 @@ func get_target(target_type: Constants.TargetType, preferences: Array[Constants.
 	print(msg)
 	return new_target
 
+
+func get_social_distancing_force(p_target: Actor, neighbours: Array[Actor]) -> Vector2:
+	var social_distancing_force : Vector2
+	
+	var social_loop_limit : int = 7
+	var distance_to_target : float = p_target.global_position.distance_to(_creator.global_position)
+	
+	for i in mini(neighbours.size(), social_loop_limit):
+		var neighbour = neighbours[i]
+		var p1 : Vector2 = _creator.global_position
+		var p2 : Vector2 = neighbour.global_position
+		var distance : float = p1.distance_to(p2)
+		if distance < distance_to_target and is_enemy(neighbour):
+			p_target = neighbour
+			distance_to_target = distance
+		var p3 : Vector2 = p1.direction_to(p2) * maxf((100 - distance * 2), 0)
+		social_distancing_force -= p3
+	
+	if neighbours.size() > social_loop_limit:
+		# Approximate the remaining social distancing force that we didn't
+		# bother calculating
+		social_distancing_force *= neighbours.size() / float(social_loop_limit)
+	
+	return social_distancing_force
+
+
+func get_steered_velocity(
+		velocity: Vector2, 
+		target_pos: Vector2, 
+		social_distancing_force := Vector2.ZERO
+) -> Vector2:
+	# determine route
+	var direction : Vector2 = _creator.global_position.direction_to(target_pos)
+	var desired_velocity : Vector2 = direction * _creator.stats.move_speed
+	var steering : Vector2 = (desired_velocity - velocity)
+	
+	# update velocity
+	velocity += steering + social_distancing_force
+	return velocity
 
 
 func _is_valid_target(candidate: Actor, group_to_target: String) -> bool:

--- a/scripts/components/actor_stats.gd
+++ b/scripts/components/actor_stats.gd
@@ -1,6 +1,8 @@
 class_name ActorStats extends Node
 ## The stats that define an actor, such as attack and defence
 
+const THRESHOLD_LOW_HEALTH = 0.25
+
 const MODIFIABLE_STATS : Array[String] = [
 	"max_health",
 	"regen",
@@ -192,3 +194,7 @@ func remove_modifier(stat_name: String, id: int) -> void:
 
 	print("Stat modifier removed from " + get_parent().debug_name + ". " + stat_name + " is now " + str(get(stat_name)))
 
+
+func is_low_health() -> bool:
+	var health_percentage := health / float(max_health)
+	return health_percentage <= THRESHOLD_LOW_HEALTH

--- a/scripts/components/state_machine.gd
+++ b/scripts/components/state_machine.gd
@@ -22,7 +22,7 @@ func _init(actor: Actor, states: Array[Constants.ActorState], states_base_folder
 	for state_name in states:
 		var _state = Factory.add_state(actor, state_name, states_base_folder)
 		add_child(_state)
-		_states[state_name] = _state	
+		_states[state_name] = _state
 	
 	if not _current_state_name in states:
 		_current_state_name = states[0]

--- a/scripts/components/state_machine.gd
+++ b/scripts/components/state_machine.gd
@@ -44,9 +44,4 @@ func _unhandled_input(event: InputEvent) -> void:
 
 func _physics_process(delta: float) -> void:
 	current_state.physics_process(delta)
-
-
-func update_state() -> void:
-	current_state.update_state()
-
-
+	current_state.decide_next_state()

--- a/scripts/data classes/unit_data.gd
+++ b/scripts/data classes/unit_data.gd
@@ -19,6 +19,8 @@ var gold_cost := 100
 var tier := 1
 var path_base_sprites := Constants.PATH_SPRITES_ACTORS
 var actions := {}
+var states: Array[Constants.ActorState] = []
+var states_base_folder := "actor"
 
 func _init(overrides := {}):
 	for key in overrides:

--- a/scripts/globals/constants.gd
+++ b/scripts/globals/constants.gd
@@ -102,6 +102,13 @@ enum ActionTrigger {
 }
 
 
+enum UnitType {
+	AI_NORMAL,
+	AI_COMMANDER,
+	PLAYER_ACTOR,
+}
+
+
 ############# PATHS ##############
 
 const PATH_ENTITIES : String = "res://scenes/entities/"
@@ -129,3 +136,7 @@ const MIN_SAFE_DISTANCE_SQUARED := pow(100, 2)
 
 const TEAM_ALLY = "ally"
 const TEAM_ENEMY = "enemy"
+
+
+static func is_commander(unit_type: UnitType) -> bool:
+	return unit_type == UnitType.AI_COMMANDER or unit_type == UnitType.PLAYER_ACTOR

--- a/scripts/globals/constants.gd
+++ b/scripts/globals/constants.gd
@@ -8,8 +8,10 @@ enum ActorState {
 	IDLING,
 	CASTING,
 	ATTACKING,
-	MOVING,
-	DEAD
+	PURSUING,
+	FLEEING,
+	DEAD,
+	PLAYER_MOVING,
 }
 
 enum Direction {
@@ -119,6 +121,9 @@ const PATH_SPRITES_EFFECTS : String = "res://sprites/effects/"
 ############ VALUES ############
 
 const MELEE_RANGE : int = 20  ## the range at which a unit is determined to be melee.
+## distance that triggers fleeing. This is squared so that we can use the cheaper method
+## `distance_squared_to` for comparissons
+const MIN_SAFE_DISTANCE_SQUARED := pow(100, 2) 
 
 ############# TEAMS ##############
 

--- a/scripts/globals/factory.gd
+++ b/scripts/globals/factory.gd
@@ -67,6 +67,22 @@ func create_player_actor(creator: Unit, name_: String, team: String) -> Actor:
 	return instance
 
 
+## create actor, pulling base data from RefData
+func create_ai_commander(creator: Unit, name_: String, team: String) -> Actor:
+	var instance := _get_base_actor_instance(creator, name_, team)
+	
+	instance.state_machine = _create_ai_commander_state_machine(instance)
+	instance.state_machine.set_name("StateMachine")
+	instance.add_child(instance.state_machine)
+	
+	instance.actor_setup()
+	
+	# now we're ready to react to the world
+	instance.set_physics_process(true)
+	
+	return instance
+
+
 func _get_base_actor_instance(
 		creator: Unit, 
 		name_ : String, 
@@ -234,6 +250,21 @@ func _create_actor_state_machine(actor: Actor) -> StateMachine:
 	]
 	
 	var state_machine : StateMachine = StateMachine.new(actor, states)
+	
+	return state_machine
+
+
+func _create_ai_commander_state_machine(actor: Actor) -> StateMachine:
+	var states : Array[Constants.ActorState] = [
+		Constants.ActorState.IDLING,
+		Constants.ActorState.CASTING,
+		Constants.ActorState.ATTACKING,
+		Constants.ActorState.PURSUING,
+		Constants.ActorState.FLEEING,
+		Constants.ActorState.DEAD,
+	]
+	
+	var state_machine : StateMachine = StateMachine.new(actor, states, "ai_commander")
 	
 	return state_machine
 

--- a/scripts/globals/factory.gd
+++ b/scripts/globals/factory.gd
@@ -229,7 +229,7 @@ func _create_actor_state_machine(actor: Actor) -> StateMachine:
 		Constants.ActorState.IDLING,
 		Constants.ActorState.CASTING,
 		Constants.ActorState.ATTACKING,
-		Constants.ActorState.MOVING,
+		Constants.ActorState.PURSUING,
 		Constants.ActorState.DEAD,
 	]
 	
@@ -243,7 +243,7 @@ func _create_player_actor_state_machine(actor: Actor) -> StateMachine:
 		Constants.ActorState.IDLING,
 		Constants.ActorState.CASTING,
 		Constants.ActorState.ATTACKING,
-		Constants.ActorState.MOVING,
+		Constants.ActorState.PLAYER_MOVING,
 		Constants.ActorState.DEAD,
 	]
 	

--- a/scripts/globals/hashgrid.gd
+++ b/scripts/globals/hashgrid.gd
@@ -21,7 +21,7 @@ func _physics_process(_delta):
 		hash_grid[tile].append(actor)
 	
 	for tile in hash_grid.keys():
-		var supa_list : Array
+		var supa_list : Array[Actor]
 		for offset in offsets:
 			var t_tile = tile + offset
 			if hash_grid.has(t_tile):

--- a/scripts/globals/ref_data.gd
+++ b/scripts/globals/ref_data.gd
@@ -63,6 +63,8 @@ func get_unit_data(unit_name: String) -> UnitData:
 				Constants.ActionType.REACTION : { },
 			}
 			value = UnitData.new({
+				"max_health": 500,
+				"attack": 25,
 				"num_units": 1,
 				"actions": actions,
 				"path_base_sprites": Constants.PATH_SPRITES_COMMANDERS
@@ -76,6 +78,8 @@ func get_unit_data(unit_name: String) -> UnitData:
 				Constants.ActionType.REACTION : { },
 			}
 			value = UnitData.new({
+				"max_health": 100,
+				"attack": 25,
 				"num_units": 1,
 				"actions": actions,
 				"path_base_sprites": Constants.PATH_SPRITES_COMMANDERS

--- a/scripts/globals/ref_data.gd
+++ b/scripts/globals/ref_data.gd
@@ -3,8 +3,10 @@ extends Node
 ##
 ## Read Only.
 
-func get_unit_data(unit_name: String) -> UnitData:
+func get_unit_data(unit_name: String, unit_type := Constants.UnitType.AI_NORMAL) -> UnitData:
 	var value: UnitData = null
+	
+	var states := _get_states_for(unit_type)
 	
 	match unit_name:
 		"copper_golem":
@@ -20,6 +22,7 @@ func get_unit_data(unit_name: String) -> UnitData:
 			}
 			value = UnitData.new({
 				"actions": actions,
+				"states": states,
 			})
 		"conjurer":
 			var actions := {  ## must use Action Type, script name (NOT class name)
@@ -37,6 +40,7 @@ func get_unit_data(unit_name: String) -> UnitData:
 				"move_speed": 200,
 				"num_units": 3,
 				"actions": actions,
+				"states": states,
 			})
 		"poet":
 			var actions := {  ## must use Action Type, script name (NOT class name)
@@ -53,6 +57,7 @@ func get_unit_data(unit_name: String) -> UnitData:
 				"move_speed": 200,
 				"num_units": 2,
 				"actions": actions,
+				"states": states,
 			})
 		"cavalier":
 			var actions := {  ## must use {Action Type, script name} (NOT class name)
@@ -62,12 +67,15 @@ func get_unit_data(unit_name: String) -> UnitData:
 				],
 				Constants.ActionType.REACTION : { },
 			}
+			
 			value = UnitData.new({
 				"max_health": 500,
 				"attack": 25,
 				"num_units": 1,
 				"actions": actions,
-				"path_base_sprites": Constants.PATH_SPRITES_COMMANDERS
+				"path_base_sprites": Constants.PATH_SPRITES_COMMANDERS,
+				"states": states,
+				"states_base_folder": "player_actor",
 			})
 		"knight":
 			var actions := {  ## must use {Action Type, script name} (NOT class name)
@@ -77,12 +85,50 @@ func get_unit_data(unit_name: String) -> UnitData:
 				],
 				Constants.ActionType.REACTION : { },
 			}
+			
 			value = UnitData.new({
 				"max_health": 100,
 				"attack": 25,
 				"num_units": 1,
 				"actions": actions,
-				"path_base_sprites": Constants.PATH_SPRITES_COMMANDERS
+				"path_base_sprites": Constants.PATH_SPRITES_COMMANDERS,
+				"states": states,
+				"states_base_folder": "ai_commander",
 			})
 	
 	return value
+
+
+func _get_states_for(unit_type: Constants.UnitType) -> Array[Constants.ActorState]:
+	var states : Array[Constants.ActorState] = []
+	
+	match unit_type:
+		Constants.UnitType.AI_NORMAL:
+			states = [
+				Constants.ActorState.IDLING,
+				Constants.ActorState.CASTING,
+				Constants.ActorState.ATTACKING,
+				Constants.ActorState.PURSUING,
+				Constants.ActorState.DEAD,
+			]
+		Constants.UnitType.PLAYER_ACTOR:
+			states = [
+				Constants.ActorState.IDLING,
+				Constants.ActorState.CASTING,
+				Constants.ActorState.ATTACKING,
+				Constants.ActorState.PLAYER_MOVING,
+				Constants.ActorState.DEAD,
+			]
+		Constants.UnitType.AI_COMMANDER:
+			states = [
+				Constants.ActorState.IDLING,
+				Constants.ActorState.CASTING,
+				Constants.ActorState.ATTACKING,
+				Constants.ActorState.PURSUING,
+				Constants.ActorState.FLEEING,
+				Constants.ActorState.DEAD,
+			]
+		_:
+			push_error("Undefined unit_type: %s"%[Constants.UnitType.keys()[unit_type]])
+	
+	return states

--- a/scripts/states/actor/attacking.gd
+++ b/scripts/states/actor/attacking.gd
@@ -16,7 +16,7 @@ func physics_process(_delta: float) -> void:
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	if _creator._target == null:
 		_creator.state_machine.change_state(Constants.ActorState.IDLING)
 

--- a/scripts/states/actor/casting.gd
+++ b/scripts/states/actor/casting.gd
@@ -13,7 +13,7 @@ func physics_process(_delta: float) -> void:
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	if _creator._target == null:
 		_creator.state_machine.change_state(Constants.ActorState.IDLING)
 

--- a/scripts/states/actor/dead.gd
+++ b/scripts/states/actor/dead.gd
@@ -15,7 +15,7 @@ func physics_process(_delta: float) -> void:
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	pass
 
 

--- a/scripts/states/actor/idling.gd
+++ b/scripts/states/actor/idling.gd
@@ -40,7 +40,7 @@ func update_state() -> void:
 		_creator._navigation_agent.target_position = _creator.global_position
 		_creator.state_machine.change_state(Constants.ActorState.CASTING)
 	elif not in_attack_range and _creator.has_ready_attack:
-		_creator.state_machine.change_state(Constants.ActorState.MOVING)
+		_creator.state_machine.change_state(Constants.ActorState.PURSUING)
 
 
 ## actions on exiting state

--- a/scripts/states/actor/idling.gd
+++ b/scripts/states/actor/idling.gd
@@ -9,11 +9,6 @@ func enter_state() -> void:
 
 
 func physics_process(_delta: float) -> void:
-	pass
-
-
-## take action based on current state
-func update_state() -> void:
 	if _creator.attack_to_cast == null:
 		_creator.attack_to_cast = _creator.actions.get_random_attack()
 		
@@ -25,7 +20,10 @@ func update_state() -> void:
 			)
 		else:
 			_creator._attempt_target_refresh()
-	
+
+
+## take action based on current state
+func decide_next_state() -> void:
 	# has no target, go idle
 	if _creator._target == null or _creator.attack_to_cast == null:
 		return

--- a/scripts/states/actor/pursuing.gd
+++ b/scripts/states/actor/pursuing.gd
@@ -14,7 +14,7 @@ func physics_process(_delta: float) -> void:
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	if _creator._target == null or _creator.attack_to_cast == null:
 		_creator.state_machine.change_state(Constants.ActorState.IDLING)
 		return

--- a/scripts/states/actor/pursuing.gd
+++ b/scripts/states/actor/pursuing.gd
@@ -4,6 +4,7 @@ extends BaseState
 ## actions on entering state
 func enter_state() -> void:
 	_creator.animated_sprite.play("walk")
+	_creator._navigation_agent.target_position = _creator._target.global_position
 
 
 
@@ -19,6 +20,7 @@ func update_state() -> void:
 		return
 	
 	_creator._navigation_agent.target_position = _creator._target.global_position
+	
 	var in_attack_range : bool = \
 			_creator._navigation_agent.distance_to_target() <= _creator.attack_to_cast.range
 	if in_attack_range and _creator.has_ready_attack:
@@ -30,4 +32,3 @@ func update_state() -> void:
 ## actions on exiting state
 func exit_state() -> void:
 	pass
-

--- a/scripts/states/ai_commander/attacking.gd
+++ b/scripts/states/ai_commander/attacking.gd
@@ -1,0 +1,23 @@
+extends "res://scripts/states/actor/attacking.gd"
+
+
+
+## take action based on current state
+func update_state() -> void:
+	if _creator._target == null:
+		_go_to_next_state()
+
+
+func _on_animated_sprite_animation_looped() -> void:
+	if _creator._target == null:
+		_go_to_next_state()
+	else:
+		_creator.attack()
+		_go_to_next_state()
+
+
+func _go_to_next_state() -> void:
+	if _creator.stats.is_low_health():
+		_creator.state_machine.change_state(Constants.ActorState.FLEEING)
+	else:
+		_creator.state_machine.change_state(Constants.ActorState.IDLING)

--- a/scripts/states/ai_commander/attacking.gd
+++ b/scripts/states/ai_commander/attacking.gd
@@ -3,7 +3,7 @@ extends "res://scripts/states/actor/attacking.gd"
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	if _creator._target == null:
 		_go_to_next_state()
 

--- a/scripts/states/ai_commander/casting.gd
+++ b/scripts/states/ai_commander/casting.gd
@@ -1,0 +1,37 @@
+extends "res://scripts/states/actor/casting.gd"
+
+var attack_range_squared := INF
+
+## actions on entering state
+func enter_state() -> void:
+	attack_range_squared = pow(_creator.attack_to_cast.range, 2)
+	super()
+
+
+## take action based on current state
+func update_state() -> void:
+	if _creator.stats.is_low_health():
+		if _creator.attack_to_cast.range <= Constants.MELEE_RANGE:
+			_creator.state_machine.change_state(Constants.ActorState.FLEEING)
+		else:
+			if _is_attack_in_range():
+				_creator.state_machine.change_state(Constants.ActorState.ATTACKING)
+	else:
+		super()
+
+
+func _on_cast_timer_timeout() -> void:
+	if _creator._target != null and _creator.has_ready_attack:
+		if _is_attack_in_range():
+			_creator.state_machine.change_state(Constants.ActorState.ATTACKING)
+		else:
+			if not _creator.stats.is_low_health():
+				_creator.state_machine.change_state(Constants.ActorState.IDLING)
+	else:
+		_creator.state_machine.change_state(Constants.ActorState.IDLING)
+
+
+func _is_attack_in_range() -> bool:
+	var distance_to_target := \
+			_creator.global_position.distance_squared_to(_creator._target.global_position)
+	return distance_to_target <= attack_range_squared

--- a/scripts/states/ai_commander/casting.gd
+++ b/scripts/states/ai_commander/casting.gd
@@ -9,7 +9,7 @@ func enter_state() -> void:
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	if _creator.stats.is_low_health():
 		if _creator.attack_to_cast.range <= Constants.MELEE_RANGE:
 			_creator.state_machine.change_state(Constants.ActorState.FLEEING)

--- a/scripts/states/ai_commander/dead.gd
+++ b/scripts/states/ai_commander/dead.gd
@@ -15,7 +15,7 @@ func physics_process(_delta: float) -> void:
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	pass
 
 

--- a/scripts/states/ai_commander/dead.gd
+++ b/scripts/states/ai_commander/dead.gd
@@ -1,0 +1,28 @@
+extends BaseState
+
+
+## actions on entering state
+func enter_state() -> void:
+	if not _creator.animated_sprite.animation_looped.is_connected(
+			_on_animated_sprite_animation_looped
+	):
+		_creator.animated_sprite.animation_looped.connect(_on_animated_sprite_animation_looped)
+	_creator.animated_sprite.play("death")
+
+
+func physics_process(_delta: float) -> void:
+	pass
+
+
+## take action based on current state
+func update_state() -> void:
+	pass
+
+
+## actions on exiting state
+func exit_state() -> void:
+	pass
+
+
+func _on_animated_sprite_animation_looped() -> void:
+	_creator.die()

--- a/scripts/states/ai_commander/fleeing.gd
+++ b/scripts/states/ai_commander/fleeing.gd
@@ -1,0 +1,53 @@
+extends BaseState
+
+const FLEE_DISTANCE = 300.0
+
+## actions on entering state
+func enter_state() -> void:
+	_creator.animated_sprite.play("walk")
+	_creator._navigation_agent.target_position = _get_flee_position()
+
+
+func unhandled_input(event: InputEvent) -> void:
+	_creator.move_towards_target()
+	_creator._refresh_facing()
+
+
+func physics_process(delta: float) -> void:
+	pass
+
+
+## take action based on current state
+func update_state() -> void:
+	if _creator._target == null or _creator._navigation_agent.is_navigation_finished():
+		_creator._navigation_agent.target_position = _creator.global_position
+		_creator.state_machine.change_state(Constants.ActorState.IDLING)
+		return
+	
+	var flee_position := _get_flee_position()
+	if _creator._navigation_agent.target_position != flee_position:
+		_creator._navigation_agent.target_position = flee_position
+
+
+## actions on exiting state
+func exit_state() -> void:
+	pass
+
+
+func _get_flee_position() -> Vector2:
+	var target_position = _creator._target.global_position
+	var away_angle := target_position.angle_to_point(_creator.global_position)
+	var flee_position := _get_position_from_polar_coordinate(
+			target_position, away_angle, FLEE_DISTANCE
+	)
+	return flee_position
+	
+
+
+func _get_position_from_polar_coordinate(
+		center_pos: Vector2, 
+		angle: float, 
+		radius: float
+) -> Vector2:
+	var value = center_pos + Vector2.from_angle(angle) * FLEE_DISTANCE
+	return value

--- a/scripts/states/ai_commander/fleeing.gd
+++ b/scripts/states/ai_commander/fleeing.gd
@@ -14,19 +14,16 @@ func unhandled_input(event: InputEvent) -> void:
 
 
 func physics_process(delta: float) -> void:
-	pass
-
-
-## take action based on current state
-func update_state() -> void:
-	if _creator._target == null or _creator._navigation_agent.is_navigation_finished():
-		_creator._navigation_agent.target_position = _creator.global_position
-		_creator.state_machine.change_state(Constants.ActorState.IDLING)
-		return
-	
 	var flee_position := _get_flee_position()
 	if _creator._navigation_agent.target_position != flee_position:
 		_creator._navigation_agent.target_position = flee_position
+
+
+## take action based on current state
+func decide_next_state() -> void:
+	if _creator._target == null or _creator._navigation_agent.is_navigation_finished():
+		_creator._navigation_agent.target_position = _creator.global_position
+		_creator.state_machine.change_state(Constants.ActorState.IDLING)
 
 
 ## actions on exiting state

--- a/scripts/states/ai_commander/idling.gd
+++ b/scripts/states/ai_commander/idling.gd
@@ -1,0 +1,30 @@
+extends "res://scripts/states/actor/idling.gd"
+
+
+var highest_range_attack: BaseAction = null
+
+func _ready() -> void:
+	var min_range := Constants.MELEE_RANGE
+	for action_uid in _creator.actions.attacks:
+		var attack := _creator.actions.attacks[action_uid] as BaseAction
+		if attack.range > min_range:
+			highest_range_attack = attack
+			min_range = attack.range
+
+
+func update_state() -> void:
+	if _creator._target != null and _creator.stats.is_low_health():
+		var distance_to_target = \
+				_creator.global_position.distance_squared_to(_creator._target.global_position)
+		if distance_to_target < Constants.MIN_SAFE_DISTANCE_SQUARED:
+			_creator.state_machine.change_state(Constants.ActorState.FLEEING)
+		else:
+			_creator.attack_to_cast = highest_range_attack
+			_creator.state_machine.change_state(Constants.ActorState.CASTING)
+	else:
+		super()
+
+
+## actions on exiting state
+func exit_state() -> void:
+	pass

--- a/scripts/states/ai_commander/idling.gd
+++ b/scripts/states/ai_commander/idling.gd
@@ -12,7 +12,7 @@ func _ready() -> void:
 			min_range = attack.range
 
 
-func update_state() -> void:
+func decide_next_state() -> void:
 	if _creator._target != null and _creator.stats.is_low_health():
 		var distance_to_target = \
 				_creator.global_position.distance_squared_to(_creator._target.global_position)

--- a/scripts/states/ai_commander/pursuing.gd
+++ b/scripts/states/ai_commander/pursuing.gd
@@ -2,7 +2,7 @@ extends "res://scripts/states/actor/pursuing.gd"
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	if _creator.stats.is_low_health():
 		_creator.state_machine.change_state(Constants.ActorState.FLEEING)
 		return

--- a/scripts/states/ai_commander/pursuing.gd
+++ b/scripts/states/ai_commander/pursuing.gd
@@ -1,0 +1,10 @@
+extends "res://scripts/states/actor/pursuing.gd"
+
+
+## take action based on current state
+func update_state() -> void:
+	if _creator.stats.is_low_health():
+		_creator.state_machine.change_state(Constants.ActorState.FLEEING)
+		return
+	
+	super()

--- a/scripts/states/base_player_state.gd
+++ b/scripts/states/base_player_state.gd
@@ -28,7 +28,7 @@ func physics_process(_delta: float) -> void:
 
 ## take action based on current state
 ## @tag virtual function
-func update_state() -> void:
+func decide_next_state() -> void:
 	pass
 
 

--- a/scripts/states/base_state.gd
+++ b/scripts/states/base_state.gd
@@ -26,7 +26,7 @@ func physics_process(_delta: float) -> void:
 
 ## take action based on current state
 ## @tag virtual function
-func update_state() -> void:
+func decide_next_state() -> void:
 	pass
 
 

--- a/scripts/states/player_actor/attacking.gd
+++ b/scripts/states/player_actor/attacking.gd
@@ -16,7 +16,7 @@ func physics_process(_delta: float) -> void:
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	if _get_current_target() == null:
 		_player.state_machine.change_state(Constants.ActorState.IDLING)
 

--- a/scripts/states/player_actor/casting.gd
+++ b/scripts/states/player_actor/casting.gd
@@ -13,7 +13,7 @@ func physics_process(_delta: float) -> void:
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	if _get_current_target() == null:
 		_player.state_machine.change_state(Constants.ActorState.IDLING)
 

--- a/scripts/states/player_actor/dead.gd
+++ b/scripts/states/player_actor/dead.gd
@@ -15,7 +15,7 @@ func physics_process(_delta: float) -> void:
 
 
 ## take action based on current state
-func update_state() -> void:
+func decide_next_state() -> void:
 	pass
 
 

--- a/scripts/states/player_actor/idling.gd
+++ b/scripts/states/player_actor/idling.gd
@@ -1,4 +1,4 @@
-extends MoveableState
+extends "moveable.gd"
 
 ## actions on entering state
 func enter_state():
@@ -17,7 +17,7 @@ func physics_process(_delta):
 func update_state():
 	super()
 	if _player.move_direction != Vector2.ZERO:
-		_player.state_machine.change_state(Constants.ActorState.MOVING)
+		_player.state_machine.change_state(Constants.ActorState.PLAYER_MOVING)
 		return
 
 

--- a/scripts/states/player_actor/idling.gd
+++ b/scripts/states/player_actor/idling.gd
@@ -9,16 +9,14 @@ func unhandled_input(event: InputEvent) -> void:
 	super(event)
 
 
-func physics_process(_delta):
-	pass
+func physics_process(delta):
+	super(delta)
 
 
 ## take action based on current state
-func update_state():
-	super()
+func decide_next_state() -> void:
 	if _player.move_direction != Vector2.ZERO:
 		_player.state_machine.change_state(Constants.ActorState.PLAYER_MOVING)
-		return
 
 
 ## actions on exiting state

--- a/scripts/states/player_actor/moveable.gd
+++ b/scripts/states/player_actor/moveable.gd
@@ -1,4 +1,3 @@
-class_name MoveableState
 extends BasePlayerState
 
 const EVENTS_ACTIONS = [

--- a/scripts/states/player_actor/moveable.gd
+++ b/scripts/states/player_actor/moveable.gd
@@ -24,7 +24,6 @@ func unhandled_input(event: InputEvent) -> void:
 				print_debug("%s has no attack for input event %s"%[_player.debug_name, action_name])
 
 
-## take action based on current state
-func update_state():
-	_player._attempt_all_target_refresh()
+func physics_process(_delta):
 	_player.move_direction = Input.get_vector("move_left", "move_right", "move_up", "move_down")
+	_player._attempt_all_target_refresh()

--- a/scripts/states/player_actor/player_moving.gd
+++ b/scripts/states/player_actor/player_moving.gd
@@ -1,4 +1,4 @@
-extends MoveableState
+extends "moveable.gd"
 
 
 ## actions on entering state

--- a/scripts/states/player_actor/player_moving.gd
+++ b/scripts/states/player_actor/player_moving.gd
@@ -10,14 +10,13 @@ func unhandled_input(event: InputEvent) -> void:
 	super(event)
 
 
-func physics_process(_delta):
+func physics_process(delta):
+	super(delta)
 	_move()
 	_player._refresh_facing()
 
 
-## take action based on current state
-func update_state():
-	super()
+func decide_next_state() -> void:
 	if _player.velocity == Vector2.ZERO:
 		_player.state_machine.change_state(Constants.ActorState.IDLING)
 


### PR DESCRIPTION
This should finish the last item remaining from #8 and touch on some of the items for #16 

It might also be a good first implementation so that we can discuss if this makes sense to you as a system for #16 or what needs to be changed for how you'd prefer to work.

## Implementation Overview
- setting navigation agent's `target_position` has been moved to `PURSUIT` state (old moving)
- ai_commander now has it's own function in factory, so that it has a state machine with the extra `FLEEING` state
- `FLEEING` was added and sets as a `target_position` a point a set distance away from the target, and moves there.
- Other states have been extended so that they have additional logic to handle low health values:
  - IDLING prioritizes running away or casting long range attacks when health is low. It will also cast in place rather than move into range because...
  - ...when health is low CASTING will wait in place if the target is not in range for the ranged attack, so it will take more of a hit and run strategy
  - ATTACKING will change to FLEEING only after it finishes its attack
  - PURSUING will be immediately interrupted and changed to FLEEING on low health.

## Limitations and/or Questions
### Am I using the factory script/pattern correctly?
I don't have any experience with this kind of approach, but for every actor that has a different state machine, with additional behaviors that might or might not be on the base actor, we will have to create two new functions in factory, is this expected? Is this how it's supposed to work? Or do you have any suggestion to improve this aspect?

I guess another approach we could take, would be to create scenes for different state_machines, already set up with their states, and just load those scenes. This way we could just add them by passing the state machine scene path and avoiding this: 
![image](https://github.com/Snayff/nqp3/assets/13070158/99fb2a84-d020-40b2-98f3-f638ebb9adf7)


### `update_state()` function
One thing I noticed while working on the state machine last week, but forgot to ask about or change is the `update_state` function. I get that semantically, the difference between `update_state` and `physics_process` is that one is for logic that can change the "state" of the state, while the other is the state processing what it has to "do".

But in the end, both are called during the engine's `_physics_process`. And I guess what bothers me the most is that `update_state` is called from `Actor`'s  `_physics_process` while `physics_process` is called from the `state_machine`'s `_physics_process`:
![image](https://github.com/Snayff/nqp3/assets/13070158/89a0ef84-ca11-4c8a-823d-e08eff447e89)
![image](https://github.com/Snayff/nqp3/assets/13070158/20f56c1f-1431-4839-9291-18fa3fcf3dbb)

I think this is something both of use overlooked when we did the state_machine refactor. Or was there a specific reason I'm not seeing for doing it this way?

**Would it be alright to change it to this?** (inside the state machine script)
```
func _physics_process(delta: float) -> void:
	current_state.update_state()
	current_state.physics_process(delta)
```
This way we know that `update_state()` always happens before or after the state processes. Maybe even return a boolean from it so that if the state has been changed, it won't still execute a last `physics_process`.
