### PR TITLE
Fix/status effect application

### DIFF
--- a/scenes/entities/actor/actor.gd
+++ b/scenes/entities/actor/actor.gd
@@ -216,7 +216,7 @@ func _on_attack() -> void:
 ## signal emitted by stats
 func _on_stamina_depleted() -> void:
 	var exhaustion = Exhaustion.new(self)
-	exhaustion.setup()
+	exhaustion.setup(self)
 	status_effects.add_status_effect(exhaustion)
 
 

--- a/scenes/entities/actor/actor.gd
+++ b/scenes/entities/actor/actor.gd
@@ -164,7 +164,8 @@ func move_towards_target() -> void:
 ## enact actor's death
 func die() -> void:
 	_collision_shape.call_deferred("set_disabled", true)  # need to call deferred as otherwise locked
-
+	_navigation_agent.avoidance_enabled = false
+	
 	animated_sprite.stop()  # its already looped back to 0 so pause == stop
 	animated_sprite.frame = animated_sprite.sprite_frames.get_frame_count("death")
 
@@ -191,9 +192,6 @@ func attack() -> void:
 ##
 ## signal emitted by stats
 func _on_health_depleted() -> void:
-	# immediately remove targetable, dont wait for animation to finish
-	is_active = false
-	is_targetable = false
 	state_machine.change_state(Constants.ActorState.DEAD)
 
 
@@ -218,6 +216,7 @@ func _on_attack() -> void:
 ## signal emitted by stats
 func _on_stamina_depleted() -> void:
 	var exhaustion = Exhaustion.new(self)
+	exhaustion.setup()
 	status_effects.add_status_effect(exhaustion)
 
 

--- a/scenes/stages/combat/stage_combat.tscn
+++ b/scenes/stages/combat/stage_combat.tscn
@@ -4,9 +4,9 @@
 [ext_resource type="Script" path="res://scenes/stages/combat/fps_counter.gd" id="2_5twv8"]
 
 [sub_resource type="NavigationPolygon" id="NavigationPolygon_qkf04"]
-vertices = PackedVector2Array(416, 240, -1, 28, -2, -3, 1158, 8, 696, 239, 407, 669, -4, 675, 1164, 653, 699, 651)
-polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3, 4), PackedInt32Array(5, 6, 1, 0), PackedInt32Array(4, 3, 7, 8)])
-outlines = Array[PackedVector2Array]([PackedVector2Array(1158, 8, 1164, 653, 699, 651, 696, 239, 416, 240, 407, 669, -4, 675, -1, 28, -2, -3)])
+vertices = PackedVector2Array(482, 290, -1, 28, -2, -3, 1158, 8, 543, 273, 407, 669, -4, 675, 405, 446, 412, 393, 436, 337, 1164, 653, 699, 651, 700, 441, 684, 386, 653, 328, 602, 286)
+polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3, 4), PackedInt32Array(5, 6, 1, 7), PackedInt32Array(8, 7, 1), PackedInt32Array(9, 8, 1), PackedInt32Array(3, 10, 11, 12), PackedInt32Array(3, 12, 13), PackedInt32Array(3, 13, 14), PackedInt32Array(0, 9, 1), PackedInt32Array(15, 4, 3), PackedInt32Array(15, 3, 14)])
+outlines = Array[PackedVector2Array]([PackedVector2Array(1158, 8, 1164, 653, 699, 651, 700, 441, 684, 386, 653, 328, 602, 286, 543, 273, 482, 290, 436, 337, 412, 393, 405, 446, 407, 669, -4, 675, -1, 28, -2, -3)])
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vjhue"]
 size = Vector2(267, 272)

--- a/scripts/actions/base_action.gd
+++ b/scripts/actions/base_action.gd
@@ -7,8 +7,11 @@ class_name BaseAction extends RefCounted
 var friendly_name : String = "":  ## name of the action, shown in the ui
 	set(value):
 		friendly_name = value
-		_cooldown_timer.set_name("CooldownTimer_" + friendly_name)
-		target_finder.set_name("TargetFinder_" + friendly_name)
+		if is_instance_valid(_cooldown_timer):
+			_cooldown_timer.set_name("CooldownTimer_" + friendly_name)
+		
+		if is_instance_valid(target_finder):
+			target_finder.set_name("TargetFinder_" + friendly_name)
 var tags : Array[Constants.ActionTag] = []  ## property tags describing the action
 var target_type : Constants.TargetType = Constants.TargetType.ENEMY  ## what target the action can effect
 var target_preferences : Array[Constants.TargetPreference] = [Constants.TargetPreference.ANY]  ## what kind of target to find, within the target type
@@ -71,20 +74,10 @@ var icon : Texture
 
 func _init(creator: Actor) -> void:
 	_creator = creator
-
+	
 	uid = Utility.generate_id()
-
-	# TODO: move components to sit under actions. They need the parents, which doesnt exist at init.
-	target_finder = Factory.add_target_finder(_creator, range)
-	target_finder.set_name("TargetFinder_" + friendly_name)
-
-	_cooldown_timer = Timer.new()
-	_cooldown_timer.set_name("CooldownTimer_" + friendly_name)
-	_creator.add_child(_cooldown_timer)
-	_cooldown_timer.set_one_shot(true)
-
+	
 	_configure()
-	_setup()
 
 
 ## configure the action's base data
@@ -94,8 +87,18 @@ func _configure() -> void:
 	assert(false, "Virtual method not overriden.")
 
 
-## last step of setup, post config
-func _setup() -> void:
+## last step of setup, post config. Should not be called on _init, causes errors because of
+## target finder being an Area and _init being a busy time for some of what it needs to do.
+func setup() -> void:
+	# TODO: move components to sit under actions. They need the parents, which doesnt exist at init.
+	target_finder = Factory.add_target_finder(_creator, range)
+	target_finder.set_name("TargetFinder_" + friendly_name)
+	
+	_cooldown_timer = Timer.new()
+	_cooldown_timer.set_name("CooldownTimer_" + friendly_name)
+	_creator.add_child(_cooldown_timer)
+	_cooldown_timer.set_one_shot(true)
+	
 	set_cooldown(cooldown)
 
 
@@ -164,7 +167,9 @@ func _effect_status(status_effect_name: String) -> void:
 	# FIXME: status not being applied
 	var action_type_ = Constants.ActionType.STATUS_EFFECT
 	var script_path : String = Utility.get_action_type_script_path(action_type_) + status_effect_name + ".gd"
-	var status_effect = load(script_path).new(_target)
+	var status_effect = load(script_path).new(_creator) as BaseStatusEffect
+	status_effect.setup()
+	status_effect._target = _target
 	_target.status_effects.add_status_effect(status_effect)
 
 

--- a/scripts/actions/base_action.gd
+++ b/scripts/actions/base_action.gd
@@ -96,7 +96,7 @@ func setup() -> void:
 	
 	_cooldown_timer = Timer.new()
 	_cooldown_timer.set_name("CooldownTimer_" + friendly_name)
-	_creator.add_child(_cooldown_timer)
+	_creator.add_child(_cooldown_timer, true)
 	_cooldown_timer.set_one_shot(true)
 	
 	set_cooldown(cooldown)
@@ -168,6 +168,7 @@ func _effect_status(status_effect_name: String) -> void:
 	var action_type_ = Constants.ActionType.STATUS_EFFECT
 	var script_path : String = Utility.get_action_type_script_path(action_type_) + status_effect_name + ".gd"
 	var status_effect = load(script_path).new(_creator) as BaseStatusEffect
+	await Engine.get_main_loop().root.get_tree().process_frame
 	status_effect.setup()
 	status_effect._target = _target
 	_target.status_effects.add_status_effect(status_effect)

--- a/scripts/actions/base_action.gd
+++ b/scripts/actions/base_action.gd
@@ -89,7 +89,9 @@ func _configure() -> void:
 
 ## last step of setup, post config. Should not be called on _init, causes errors because of
 ## target finder being an Area and _init being a busy time for some of what it needs to do.
-func setup() -> void:
+func setup(p_target: Actor) -> void:
+	_target = p_target
+	
 	# TODO: move components to sit under actions. They need the parents, which doesnt exist at init.
 	target_finder = Factory.add_target_finder(_creator, range)
 	target_finder.set_name("TargetFinder_" + friendly_name)
@@ -168,9 +170,10 @@ func _effect_status(status_effect_name: String) -> void:
 	var action_type_ = Constants.ActionType.STATUS_EFFECT
 	var script_path : String = Utility.get_action_type_script_path(action_type_) + status_effect_name + ".gd"
 	var status_effect = load(script_path).new(_creator) as BaseStatusEffect
+	
 	await Engine.get_main_loop().root.get_tree().process_frame
-	status_effect.setup()
-	status_effect._target = _target
+	
+	status_effect.setup(_target)
 	_target.status_effects.add_status_effect(status_effect)
 
 

--- a/scripts/actions/base_action.gd
+++ b/scripts/actions/base_action.gd
@@ -1,30 +1,27 @@
-class_name BaseAction extends Node
+class_name BaseAction extends RefCounted
 ## base class for a combat action for actors
 
 
 ########### CONFIG #############
 
-@export_group("config")
-@export var friendly_name : String = "":  ## name of the action, shown in the ui
+var friendly_name : String = "":  ## name of the action, shown in the ui
 	set(value):
 		friendly_name = value
 		_cooldown_timer.set_name("CooldownTimer_" + friendly_name)
 		target_finder.set_name("TargetFinder_" + friendly_name)
-@export var tags : Array[Constants.ActionTag] = []  ## property tags describing the action
-@export var target_type : Constants.TargetType = Constants.TargetType.ENEMY  ## what target the action can effect
-@export var target_preferences : Array[Constants.TargetPreference] = [Constants.TargetPreference.ANY]  ## what kind of target to find, within the target type
-@export var trigger : Constants.ActionTrigger = Constants.ActionTrigger.ATTACK  ## what triggers the action
-@export var action_type : Constants.ActionType = Constants.ActionType.ATTACK
-@export var target_selection : Constants.ActionTargetSelection = Constants.ActionTargetSelection.ACTOR  ## what thing is selected to cast the action
+var tags : Array[Constants.ActionTag] = []  ## property tags describing the action
+var target_type : Constants.TargetType = Constants.TargetType.ENEMY  ## what target the action can effect
+var target_preferences : Array[Constants.TargetPreference] = [Constants.TargetPreference.ANY]  ## what kind of target to find, within the target type
+var trigger : Constants.ActionTrigger = Constants.ActionTrigger.ATTACK  ## what triggers the action
+var action_type : Constants.ActionType = Constants.ActionType.ATTACK
+var target_selection : Constants.ActionTargetSelection = Constants.ActionTargetSelection.ACTOR  ## what thing is selected to cast the action
 
-@export var _base_stamina_cost : int = 0
-@export var _base_cooldown : float = 0.0
-@export var _base_damage : int = 0
-@export var _base_damage_type : Constants.DamageType = Constants.DamageType.MUNDANE
-@export var _base_range : int = 0
-@export var _base_cast_time : float = 0.0
-
-@export_group("", "")  # end grouping
+var _base_stamina_cost : int = 0
+var _base_cooldown : float = 0.0
+var _base_damage : int = 0
+var _base_damage_type : Constants.DamageType = Constants.DamageType.MUNDANE
+var _base_range : int = 0
+var _base_cast_time : float = 0.0
 
 ######### ATTRIBUTES ##########
 

--- a/scripts/actions/status_effects/base_status_effect.gd
+++ b/scripts/actions/status_effects/base_status_effect.gd
@@ -31,16 +31,30 @@ var stat_modifiers: Array[StatModifier] = []
 func _init(creator: Actor) -> void:
 	super(creator)
 
+
+func setup() -> void:
+	super()
 	# setup new timer for duration
 	_duration_timer = Timer.new()
 	_duration_timer.set_name("DurationTimer")
 	_duration_timer.timeout.connect(on_duration_expiry)
+	_creator.add_child(_duration_timer)
+	set_duration(_base_duration)
 
 	# override core functionality to make the action work as a recurring effect
 	_cooldown_timer.set_one_shot(false)
 
 	# trigger action on cooldown
 	_cooldown_timer.timeout.connect(apply_status_effect)
+
+
+func destroy() -> void:
+	print("destroying %s from %s %s"%[friendly_name, _target, uid])
+	_duration_timer.stop()
+	_duration_timer.queue_free()
+	_cooldown_timer.stop()
+	_cooldown_timer.queue_free()
+	target_finder.queue_free()
 
 
 ## wrapper for use()
@@ -58,8 +72,4 @@ func set_duration(duration_time: float) -> void:
 
 
 func on_duration_expiry() -> void:
-	emit_signal("expired")
-	# TODO: remove stat mods and self
-
-
-
+	expired.emit()

--- a/scripts/actions/status_effects/base_status_effect.gd
+++ b/scripts/actions/status_effects/base_status_effect.gd
@@ -36,9 +36,9 @@ func setup() -> void:
 	super()
 	# setup new timer for duration
 	_duration_timer = Timer.new()
-	_duration_timer.set_name("DurationTimer")
+	_duration_timer.set_name("DurationTimer_%s"%[friendly_name])
 	_duration_timer.timeout.connect(on_duration_expiry)
-	_creator.add_child(_duration_timer)
+	_creator.add_child(_duration_timer, true)
 	set_duration(_base_duration)
 
 	# override core functionality to make the action work as a recurring effect

--- a/scripts/actions/status_effects/base_status_effect.gd
+++ b/scripts/actions/status_effects/base_status_effect.gd
@@ -32,8 +32,9 @@ func _init(creator: Actor) -> void:
 	super(creator)
 
 
-func setup() -> void:
-	super()
+func setup(p_target: Actor) -> void:
+	super(p_target)
+	
 	# setup new timer for duration
 	_duration_timer = Timer.new()
 	_duration_timer.set_name("DurationTimer_%s"%[friendly_name])

--- a/scripts/components/actor_stats.gd
+++ b/scripts/components/actor_stats.gd
@@ -56,11 +56,11 @@ var _modifiers : Dictionary = {}
 	set(value):
 		var previous_stamina : int = stamina
 		stamina = clamp(value, 0, max_stamina)
-		emit_signal("stamina_changed", previous_stamina, stamina)
+		stamina_changed.emit(previous_stamina, stamina)
 
 		# inform of death
 		if stamina == 0:
-			emit_signal("stamina_depleted")
+			stamina_depleted.emit()
 
 # defence stats
 @export_group("Defence")

--- a/scripts/components/actor_status_effects.gd
+++ b/scripts/components/actor_status_effects.gd
@@ -18,6 +18,7 @@ var _effects : Dictionary = {}  ## Dict[int, BaseStatusEffect]   {uid, BaseStatu
 func add_status_effect(status_effect: BaseStatusEffect) -> void:
 	# dont add more than 1 of same status effect
 	if _has_effect_already(status_effect):
+		status_effect.destroy()
 		return
 	
 	_effects[status_effect.uid] = status_effect

--- a/scripts/components/actor_status_effects.gd
+++ b/scripts/components/actor_status_effects.gd
@@ -19,14 +19,16 @@ func add_status_effect(status_effect: BaseStatusEffect) -> void:
 	# dont add more than 1 of same status effect
 	if _has_effect_already(status_effect):
 		return
-
+	
 	_effects[status_effect.uid] = status_effect
 	print(status_effect.friendly_name + " added to " + get_parent().debug_name + ".")
-
+	
 	# signal for  all stat mods, to be picked up in Actor
 	for stat_mod in status_effect.stat_modifiers:
 		emit_signal("stat_modifier_added", stat_mod)
-
+	
+	status_effect.expired.connect(remove_status_effect.bind(status_effect.uid))
+	
 	# inform of addition
 	emit_signal("status_effect_added")
 
@@ -35,14 +37,18 @@ func add_status_effect(status_effect: BaseStatusEffect) -> void:
 func remove_status_effect(uid: int) -> void:
 	if not uid in _effects:
 		push_warning("Tried to remove status effect (" + str(uid) + ") that doesnt exist.")
-
+	
 	_trigger_stat_mod_removal(uid)
-
+	
+	var status_effect := _effects[uid] as BaseStatusEffect
 	# del status effect
 	_effects.erase(uid)
-
+	
+	status_effect.destroy()
+	
 	# inform of removal
 	emit_signal("status_effect_removed")
+
 
 ## remove status effect by type
 func remove_status_effect_by_type(status_effect: BaseStatusEffect) -> void:
@@ -62,6 +68,12 @@ func remove_status_effect_by_type(status_effect: BaseStatusEffect) -> void:
 			return
 
 
+func clear_all_status_effects() -> void:
+	var uid_list := _effects.keys()
+	for uid in uid_list:
+		remove_status_effect(uid)
+
+
 ## confirm if a status effect of same type already exists on actor
 func _has_effect_already(status_effect: BaseStatusEffect) -> bool:
 	for effect in _effects.values():
@@ -74,5 +86,5 @@ func _has_effect_already(status_effect: BaseStatusEffect) -> bool:
 ##
 ## picked up in actor
 func _trigger_stat_mod_removal(uid: int) -> void:
-	for stat_mod in _effects[uid].stats_modified:
+	for stat_mod in _effects[uid].stat_modifiers:
 		emit_signal("stat_modifier_removed", stat_mod.stat_name, stat_mod.uid)

--- a/scripts/globals/combat.gd
+++ b/scripts/globals/combat.gd
@@ -53,7 +53,7 @@ func _reduce_damage_by_defence(base_damage: int, defender: Actor, damage_type: C
 
 ## reduce an actor's stamina
 func reduce_stamina(target: Actor, amount: int) -> void:
-	target.stats.stamina -= min(amount, 0)
+	target.stats.stamina -= max(amount, 0)
 
 
 ## instantly kill actor

--- a/scripts/globals/factory.gd
+++ b/scripts/globals/factory.gd
@@ -324,7 +324,7 @@ func create_simple_animation(animation_name: String) -> SimpleAnimation:
 func add_target_finder(creator: Actor, radius: int, is_visible: bool = false, colour: Color = Color(0, 0, 0, 0)) -> TargetFinder:
 	#print("Creating new target finder for " + creator.debug_name + " ===========>")
 	var target_finder : TargetFinder = _TargetFinder.instantiate()
-	creator.add_child(target_finder)  # need to add child to trigger the onready stuff
+	creator.add_child(target_finder, true)  # need to add child to trigger the onready stuff
 	target_finder.radius = radius
 	target_finder.is_visible = is_visible
 	target_finder.global_position = creator.global_position

--- a/scripts/globals/factory.gd
+++ b/scripts/globals/factory.gd
@@ -194,6 +194,7 @@ func _get_action(
 	var script_path : String = \
 			Utility.get_action_type_script_path(action_type).path_join(action_name + ".gd")
 	var script : BaseAction = load(script_path).new(instance)
+	script.setup()
 	return script
 
 

--- a/scripts/globals/factory.gd
+++ b/scripts/globals/factory.gd
@@ -168,8 +168,6 @@ func _add_actor_actions(instance: Actor, unit_data: UnitData) -> Actor:
 			for action_name in unit_data.actions[action_type]:
 				var script := _get_action(instance, action_type, action_name)
 				actions.add_attack(script)
-				script.set_name(script.friendly_name)
-				actions.add_child(script)
 			
 		# reactions are Dictionary[ActionType, Dictionary[ActionTrigger, Array[String]]
 		elif action_type == Constants.ActionType.REACTION:
@@ -177,8 +175,6 @@ func _add_actor_actions(instance: Actor, unit_data: UnitData) -> Actor:
 				for action_name in unit_data["actions"][action_type][trigger]:
 					var script := _get_action(instance, action_type, action_name)
 					actions.add_reaction(script, trigger)
-					script.set_name(script.friendly_name)
-					actions.add_child(script)
 			
 		else:
 			# we only add attacks and reactions, ignore everything else

--- a/scripts/globals/factory.gd
+++ b/scripts/globals/factory.gd
@@ -194,7 +194,7 @@ func _get_action(
 	var script_path : String = \
 			Utility.get_action_type_script_path(action_type).path_join(action_name + ".gd")
 	var script : BaseAction = load(script_path).new(instance)
-	script.setup()
+	script.setup(null)
 	return script
 
 

--- a/scripts/states/actor/dead.gd
+++ b/scripts/states/actor/dead.gd
@@ -3,9 +3,14 @@ extends BaseState
 
 ## actions on entering state
 func enter_state() -> void:
+	# immediately remove targetable, dont wait for animation to finish
+	_creator.is_active = false
+	_creator.is_targetable = false
 	_creator.add_to_group("dead")
 	_creator.remove_from_group("alive")
 	_creator.stats.health = 0
+	
+	_creator.status_effects.clear_all_status_effects()
 	
 	if not _creator.animated_sprite.animation_looped.is_connected(
 			_on_animated_sprite_animation_looped


### PR DESCRIPTION
A series of fixes and improvements to status effects system:
- Make actions and status_effects (specialized actions) inherit from `RefCounted` instead of `Node`s
  Actions were actually being added to the SceneTree but status effects weren't, which makes them orphan nodes, but to change one I need to change both. Also neither was using any of `Node`'s functions so it was kind of wasteful to use `Node`.
- Improved initialization and destruction of status effects
  - adding `TargetFinder` nodes during `_init`  was raising errors about using `set_disable` directly, and while we were not using `set_disabled` the Godot though we were because it was trying to add `TargetFinder` to the tree inside another `_init`
  - Fixed adding and removing Cooldown timers to the three and connecting signals.
  - Remove outstanding status effects when actor dies
 
Some other fixes unrelated to status effects that I found while exploring this:
- Fix stamina not being depleted at all.
- Changed stage's navigation region to make it less prone to getting actors stuck on corners.
- Allow Actors to step over dead actors. Just disabling the collision wasn't enough as avoidance was still turned on.

Video from dev:

https://github.com/Snayff/nqp3/assets/13070158/fb5f5fed-9c3c-4182-9ff9-df9063b04f9d

Video after PR:

https://github.com/Snayff/nqp3/assets/13070158/fc37f692-a38a-442d-aab3-89cc463743be

