### PR TITLE
Implement more triggers for Reactions

### DIFF
--- a/scenes/entities/actor/actor.gd
+++ b/scenes/entities/actor/actor.gd
@@ -105,10 +105,14 @@ var is_selectable : bool = true:
 		if not is_selectable:
 			is_selected = false
 
+######### ON_MOVE properties ###############
+
+var _previous_position := Vector2.ZERO
 
 ######### SETUP #############
 
 func _ready() -> void:
+	_previous_position = global_position
 	pass
 
 
@@ -149,7 +153,11 @@ func _connect_signals() -> void:
 ########## MAIN LOOP ##########
 
 func _physics_process(_delta) -> void:
-	pass
+	var moved_by := global_position - _previous_position
+	_previous_position = global_position
+	if moved_by != Vector2.ZERO:
+		actions.trigger_reactions(
+				Constants.ActionTrigger.ON_MOVE, self, {"movement_delta": moved_by})
 
 ######### ACTIONS ############
 

--- a/scenes/entities/actor/actor.gd
+++ b/scenes/entities/actor/actor.gd
@@ -198,7 +198,8 @@ func _on_health_depleted() -> void:
 func _on_took_damage(_amount: int, _damage_type: Constants.DamageType) -> void:
 	# flash damage indicator
 	var tween = get_tree().create_tween()
-	tween.tween_property(animated_sprite, "modulate", Color.RED, 0.1)  # FIXME: never goes back to normal colour
+	tween.tween_property(animated_sprite, "modulate", Color.RED, 0.1)
+	tween.tween_property(animated_sprite, "modulate", Color.WHITE, 0.2)
 
 
 func _on_death() -> void:

--- a/scenes/entities/actor/actor.gd
+++ b/scenes/entities/actor/actor.gd
@@ -133,7 +133,7 @@ func actor_setup() -> void:
 func _connect_signals() -> void:
 	# conect to own signals
 	died.connect(_on_death)
-	hit_received.connect(_on_hit_received)
+	took_damage.connect(_on_took_damage)
 
 	# connect to (script) component signals
 	stats.health_depleted.connect(_on_health_depleted)
@@ -195,12 +195,10 @@ func _on_health_depleted() -> void:
 	state_machine.change_state(Constants.ActorState.DEAD)
 
 
-func _on_hit_received(attacker: Actor) -> void:
+func _on_took_damage(_amount: int, _damage_type: Constants.DamageType) -> void:
 	# flash damage indicator
 	var tween = get_tree().create_tween()
 	tween.tween_property(animated_sprite, "modulate", Color.RED, 0.1)  # FIXME: never goes back to normal colour
-
-	actions.trigger_reactions(Constants.ActionTrigger.ON_RECEIVE_DAMAGE, attacker)
 
 
 func _on_death() -> void:

--- a/scripts/actions/attacks/heal.gd
+++ b/scripts/actions/attacks/heal.gd
@@ -12,7 +12,7 @@ func _configure() -> void:
 	_base_range = 100
 
 
-func use(initial_target: Actor) -> void:
+func use(initial_target: Actor, optional_parameters := {}) -> void:
 	super(initial_target)
 	
 	var visual = Factory.create_simple_animation("heal")

--- a/scripts/actions/attacks/smash.gd
+++ b/scripts/actions/attacks/smash.gd
@@ -14,7 +14,7 @@ func _configure() -> void:
 	_base_range = Constants.MELEE_RANGE
 
 
-func use(initial_target: Actor) -> void:
+func use(initial_target: Actor, optional_parameters := {}) -> void:
 	super(initial_target)
 
 	var sparkles = Factory.create_sparkles(_get_sparkles_data())

--- a/scripts/actions/attacks/stanza.gd
+++ b/scripts/actions/attacks/stanza.gd
@@ -17,7 +17,7 @@ func _configure() -> void:
 	_base_range = 500.0
 
 
-func use(initial_target: Actor) -> void:
+func use(initial_target: Actor, optional_parameters := {}) -> void:
 	super(initial_target)
 
 	# get all targets in range

--- a/scripts/actions/attacks/wand_blast.gd
+++ b/scripts/actions/attacks/wand_blast.gd
@@ -14,7 +14,7 @@ func _configure() -> void:
 	_base_range = 100
 
 
-func use(initial_target: Actor) -> void:
+func use(initial_target: Actor, optional_parameters := {}) -> void:
 	super(initial_target)
 
 	if not _creator.is_melee:

--- a/scripts/actions/base_action.gd
+++ b/scripts/actions/base_action.gd
@@ -110,7 +110,7 @@ func setup(p_target: Actor) -> void:
 ## use action on a target
 ##
 ## must call super in subclass; this updates _target and charges stamina cost
-func use(initial_target: Actor) -> void:
+func use(initial_target: Actor, optional_parameters := {}) -> void:
 	_target = initial_target
 	Combat.reduce_stamina(_creator, _base_stamina_cost)
 

--- a/scripts/actions/base_action.gd
+++ b/scripts/actions/base_action.gd
@@ -18,6 +18,7 @@ var target_preferences : Array[Constants.TargetPreference] = [Constants.TargetPr
 var trigger : Constants.ActionTrigger = Constants.ActionTrigger.ATTACK  ## what triggers the action
 var action_type : Constants.ActionType = Constants.ActionType.ATTACK
 var target_selection : Constants.ActionTargetSelection = Constants.ActionTargetSelection.ACTOR  ## what thing is selected to cast the action
+var should_trigger_reactions := true
 
 var _base_stamina_cost : int = 0
 var _base_cooldown : float = 0.0
@@ -154,7 +155,7 @@ func _effect_new_target(
 ## apply amount of damage to current target. returns damage dealth
 func _effect_damage(amount: int, damage_type: Constants.DamageType) -> int:
 	var damage = Combat.calculate_damage(_creator, _target, amount, damage_type)
-	Combat.deal_damage(_creator, _target, damage, damage_type)
+	Combat.deal_damage(_creator, _target, damage, damage_type, should_trigger_reactions)
 
 	return damage
 

--- a/scripts/actions/base_action.gd
+++ b/scripts/actions/base_action.gd
@@ -18,7 +18,7 @@ var target_preferences : Array[Constants.TargetPreference] = [Constants.TargetPr
 var trigger : Constants.ActionTrigger = Constants.ActionTrigger.ATTACK  ## what triggers the action
 var action_type : Constants.ActionType = Constants.ActionType.ATTACK
 var target_selection : Constants.ActionTargetSelection = Constants.ActionTargetSelection.ACTOR  ## what thing is selected to cast the action
-var should_trigger_reactions := true
+var should_trigger_damage_reactions := true
 
 var _base_stamina_cost : int = 0
 var _base_cooldown : float = 0.0
@@ -155,7 +155,7 @@ func _effect_new_target(
 ## apply amount of damage to current target. returns damage dealth
 func _effect_damage(amount: int, damage_type: Constants.DamageType) -> int:
 	var damage = Combat.calculate_damage(_creator, _target, amount, damage_type)
-	Combat.deal_damage(_creator, _target, damage, damage_type, should_trigger_reactions)
+	Combat.deal_damage(_creator, _target, damage, damage_type, should_trigger_damage_reactions)
 
 	return damage
 

--- a/scripts/actions/reactions/spiky_shell.gd
+++ b/scripts/actions/reactions/spiky_shell.gd
@@ -4,6 +4,7 @@ func _configure() -> void:
 	friendly_name = "Spiky Shell"
 	tags = [Constants.ActionTag.DAMAGE]
 	target_type = Constants.TargetType.ATTACKER
+	should_trigger_reactions = false
 	_base_cooldown = 0
 	_base_damage = 5
 	_base_stamina_cost = 0
@@ -11,7 +12,6 @@ func _configure() -> void:
 
 func use(initial_target: Actor) -> void:
 	super(initial_target)
-
 	_effect_damage(_base_damage + (_creator.stats.mundane_defence * 0.1) , Constants.DamageType.MUNDANE)
 
 

--- a/scripts/actions/reactions/spiky_shell.gd
+++ b/scripts/actions/reactions/spiky_shell.gd
@@ -10,7 +10,7 @@ func _configure() -> void:
 	_base_stamina_cost = 0
 
 
-func use(initial_target: Actor) -> void:
+func use(initial_target: Actor, optional_parameters := {}) -> void:
 	super(initial_target)
 	_effect_damage(_base_damage + (_creator.stats.mundane_defence * 0.1) , Constants.DamageType.MUNDANE)
 

--- a/scripts/actions/reactions/spiky_shell.gd
+++ b/scripts/actions/reactions/spiky_shell.gd
@@ -4,7 +4,7 @@ func _configure() -> void:
 	friendly_name = "Spiky Shell"
 	tags = [Constants.ActionTag.DAMAGE]
 	target_type = Constants.TargetType.ATTACKER
-	should_trigger_reactions = false
+	should_trigger_damage_reactions = false
 	_base_cooldown = 0
 	_base_damage = 5
 	_base_stamina_cost = 0

--- a/scripts/actions/status_effects/exhaustion.gd
+++ b/scripts/actions/status_effects/exhaustion.gd
@@ -26,7 +26,7 @@ func _configure() -> void:
 	stat_modifiers.append(stat_mod)
 
 
-func use(initial_target: Actor) -> void:
+func use(initial_target: Actor, optional_parameters := {}) -> void:
 	super(initial_target)
 
 	# no further action beyond stat mod

--- a/scripts/actions/status_effects/motivation.gd
+++ b/scripts/actions/status_effects/motivation.gd
@@ -17,7 +17,7 @@ func _configure() -> void:
 
 
 # called everytime duration == 0
-func use(initial_target: Actor) -> void:
+func use(initial_target: Actor, optional_parameters := {}) -> void:
 	super(initial_target)
 
 

--- a/scripts/actions/status_effects/poison.gd
+++ b/scripts/actions/status_effects/poison.gd
@@ -12,7 +12,7 @@ func _configure() -> void:
 	stat_modifiers.append(weaken)
 
 
-func use(initial_target: Actor) -> void:
+func use(initial_target: Actor, optional_parameters := {}) -> void:
 	super(initial_target)
 
 	_effect_damage(_base_damage, _base_damage_type)

--- a/scripts/components/actor_actions.gd
+++ b/scripts/components/actor_actions.gd
@@ -98,14 +98,18 @@ func remove_reaction(trigger: Constants.ActionTrigger, uid: int) -> void:
 
 
 ## use all actions of given type, reset cooldown after use
-func trigger_reactions(trigger: Constants.ActionTrigger, target: Actor) -> void:
+func trigger_reactions(
+		trigger: Constants.ActionTrigger, 
+		target: Actor, 
+		optional_parameters := {}
+) -> void:
 	if not trigger in reactions:
 		return
 	
 	for reaction in reactions[trigger].values():
 		if reaction.is_ready:
 			print(name +  " used " + reaction.friendly_name + ".")
-			reaction.use(target)
+			reaction.use(target, optional_parameters)
 			reaction.reset_cooldown()
 
 

--- a/scripts/components/actor_actions.gd
+++ b/scripts/components/actor_actions.gd
@@ -101,9 +101,9 @@ func remove_reaction(trigger: Constants.ActionTrigger, uid: int) -> void:
 func trigger_reactions(trigger: Constants.ActionTrigger, target: Actor) -> void:
 	if not trigger in reactions:
 		return
-
+	
 	for reaction in reactions[trigger].values():
-		if reaction.is_ready():
+		if reaction.is_ready:
 			print(name +  " used " + reaction.friendly_name + ".")
 			reaction.use(target)
 			reaction.reset_cooldown()

--- a/scripts/components/actor_stats.gd
+++ b/scripts/components/actor_stats.gd
@@ -47,7 +47,7 @@ var _modifiers : Dictionary = {}
 		health = clamp(value, 0, max_health)
 		if previous_health != health:
 			emit_signal("health_changed", previous_health, health)
-		
+			
 			# inform of death
 			if health == 0:
 				emit_signal("health_depleted")

--- a/scripts/globals/combat.gd
+++ b/scripts/globals/combat.gd
@@ -2,26 +2,36 @@ extends Node
 ## Combat functionality.
 
 ## allocate damage and signal interactions
-func deal_damage(attacker: Actor, defender: Actor, damage: int, damage_type: Constants.DamageType) -> void:
-	attacker.emit_signal("dealt_damage", [damage, damage_type])
-
+func deal_damage(
+		attacker: Actor, 
+		defender: Actor, 
+		damage: int, 
+		damage_type: Constants.DamageType,
+		should_trigger_reactions := true
+) -> void:
+	attacker.dealt_damage.emit(damage, damage_type)
+	
 	defender.stats.health -= damage
-	defender.emit_signal("took_damage", [damage, damage_type])
-	defender.emit_signal("hit_received", attacker)
-
+	defender.took_damage.emit(damage, damage_type)
+	
+	if should_trigger_reactions:
+		attacker.actions.trigger_reactions(Constants.ActionTrigger.ON_DEAL_DAMAGE, defender)
+		defender.actions.trigger_reactions(Constants.ActionTrigger.ON_RECEIVE_DAMAGE, attacker)
+	
 	# debug gubbins
 	var team : String = ""
 	if attacker.is_in_group(Constants.TEAM_ALLY):
 		team = Constants.TEAM_ALLY
 	else:
 		team = Constants.TEAM_ENEMY
-
+	
 	var team2 : String = ""
 	if defender.is_in_group(Constants.TEAM_ALLY):
 		team2 = Constants.TEAM_ALLY
 	else:
 		team2 = Constants.TEAM_ENEMY
-
+	
+	
 	print(attacker.debug_name + " dealt " + str(damage) + " to " + defender.debug_name + ". Remaining health is " + str(defender.stats.health) + ".")
 
 

--- a/scripts/globals/combat.gd
+++ b/scripts/globals/combat.gd
@@ -7,16 +7,19 @@ func deal_damage(
 		defender: Actor, 
 		damage: int, 
 		damage_type: Constants.DamageType,
-		should_trigger_reactions := true
+		should_trigger_damage_reactions := true
 ) -> void:
 	attacker.dealt_damage.emit(damage, damage_type)
 	
 	defender.stats.health -= damage
 	defender.took_damage.emit(damage, damage_type)
 	
-	if should_trigger_reactions:
+	if should_trigger_damage_reactions:
 		attacker.actions.trigger_reactions(Constants.ActionTrigger.ON_DEAL_DAMAGE, defender)
 		defender.actions.trigger_reactions(Constants.ActionTrigger.ON_RECEIVE_DAMAGE, attacker)
+	
+	if defender.stats.health == 0:
+		attacker.actions.trigger_reactions(Constants.ActionTrigger.ON_KILL, defender)
 	
 	# debug gubbins
 	var team : String = ""
@@ -74,11 +77,12 @@ func kill(attacker: Actor, target: Actor) -> void:
 
 ## restore health and signal interactions
 func heal(healer: Actor, target: Actor, heal_amount: int) -> void:
-	healer.emit_signal("healed_someone", heal_amount)
+	healer.healed_someone.emit(heal_amount)
+	healer.actions.trigger_reactions(Constants.ActionTrigger.ON_HEAL, target)
 	
 	var new_health = min(target.stats.health + heal_amount, target.stats.max_health)
 	heal_amount = (new_health - target.stats.health) as int
 	target.stats.health = new_health
-	target.emit_signal("was_healed", heal_amount)
+	target.was_healed.emit(heal_amount)
 	
 	print(healer.debug_name + " healed " + str(heal_amount) + " to " + target.debug_name + ". Health is now " + str(target.stats.health) + ".")

--- a/scripts/globals/ref_data.gd
+++ b/scripts/globals/ref_data.gd
@@ -15,7 +15,7 @@ func get_unit_data(unit_name: String, unit_type := Constants.UnitType.AI_NORMAL)
 					"smash",
 				],
 				Constants.ActionType.REACTION : {
-					Constants.ActionTrigger.ON_DEAL_DAMAGE : [
+					Constants.ActionTrigger.ON_RECEIVE_DAMAGE : [
 						"spiky_shell",
 					]
 				}


### PR DESCRIPTION
This PR:
- **fixes spiky shield from `ON_DEAL_DAMAGE` to `ON_RECEIVE_DAMAGE`**
- **Implements `ON_DEAL_DAMAGE ` and refactors how `ON_RECEIVE_DAMAGE` is triggered to avoid infinite recursions**
  Here I ended up going with a very simple version of the third alternative we discussed on discord, that is preventing damage reactions from triggering other damage reactions.

  To do that I moved `ON_RECEIVE_DAMAGE` from the actor to the Combat script, and added an optional parameter on `deal_damage` function. Also added a new property on BaseAction, that you can set to false on the `configure` function of any action you want to not trigger damage reactions. 
  
  If you prefer the Timer approach more than this one let me know, and I'll change it.
- **Implements `ON_HEAL` trigger**
  This is triggering on the healer, but if it should be triggered on the healed, let me know, it's a simple change.
- **Implements `ON_KILL` trigger**
- **Implements `ON_MOVE` trigger**
  After your examples on discord I implemented it on a simple way directly on Actor. It will only trigger if any movement is detected and will pass to the reaction the amount moved. Then the reaction can use it's own logic to determine if it has moved enough to use its effect or not.